### PR TITLE
Fix condition preventing windows being centered

### DIFF
--- a/window/window.go
+++ b/window/window.go
@@ -92,7 +92,7 @@ func New() (*Window, error) {
 		sdlflags |= sdl.WINDOW_ALLOW_HIGHDPI
 	}
 
-	if !config.Fullscreen {
+	if config.Fullscreen {
 		// The position needs to be in the global coordinate space.
 		var displaybounds sdl.Rect
 		sdl.GetDisplayBounds(config.Display, &displaybounds)


### PR DESCRIPTION
I could not get a new window to be centered when specifying "centered = true" in conf.toml, changing this if condition _seems_ to fix it.

I really appreciate the effort here. I know it's just experimental right now but I think the love2d approach is a really good fit for Go.

PS, any chance you could add a license to the project?
