### PR TITLE
Fix usage of go-mp3

### DIFF
--- a/audio/decoding/mp3.go
+++ b/audio/decoding/mp3.go
@@ -33,7 +33,7 @@ type mp3Reader struct {
 	readBytes int
 	pos       int
 	source    io.Closer
-	decoder   *mp3.Decoded
+	decoder   *mp3.Decoder
 }
 
 func (d *mp3Reader) readUntil(pos int) error {


### PR DESCRIPTION
Decoded got renamed to Decoder in https://github.com/hajimehoshi/go-mp3/commit/7af981645c960289dd8cedc9c3b3fe2b09d25c26